### PR TITLE
fix: enhance number validation in ApiTransactionCreateSchema

### DIFF
--- a/src/domain/transaction-domain/transation-schema.ts
+++ b/src/domain/transaction-domain/transation-schema.ts
@@ -17,10 +17,15 @@ export const CreateTransactionNumberToNumberSchema = z.object({
 export const ApiTransactionCreateSchema = z.object({
   amount: z.preprocess(
     (val) => {
-      // Attempt to parse if it's a string, otherwise pass through
+      // Only accept strings that are valid numbers (integer or decimal)
       if (typeof val === "string") {
-        const parsed = parseFloat(val);
-        return isNaN(parsed) ? val : parsed; // Return original string if parsing failed
+        // Regex matches optional leading +/-, digits, optional decimal, optional exponent
+        const validNumberPattern = /^[-+]?\d*(\.\d+)?([eE][-+]?\d+)?$/;
+        if (validNumberPattern.test(val.trim()) && val.trim() !== "") {
+          const parsed = parseFloat(val);
+          return isNaN(parsed) ? undefined : parsed;
+        }
+        return undefined; // Invalid string, will fail number validation
       }
       return val;
     },

--- a/tests/unit/transation-schema.unit.test.ts
+++ b/tests/unit/transation-schema.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { ApiTransactionCreateSchema } from "../../src/domain/transaction-domain/transation-schema";
+
+// Helper for schema parsing
+function safeParse(schema: any, data: any) {
+  const result = schema.safeParse(data);
+  return result;
+}
+
+describe("ApiTransactionCreateSchema", () => {
+  describe("valid cases", () => {
+    it("accepts amount as a number", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: 1.5,
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts amount as a valid string number", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: "2.3",
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts amount as a valid scientific notation string", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: "1e3",
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("invalid cases", () => {
+    it("rejects amount as an invalid string with letters", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: "1mama123",
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects amount as an empty string", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: "",
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects amount as zero", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: 0,
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects amount as negative", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: -1,
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing amount", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        toBankNumber: "1234567890123455/5555",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing toBankNumber", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: 1,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid toBankNumber format", () => {
+      const result = safeParse(ApiTransactionCreateSchema, {
+        amount: 1,
+        toBankNumber: "1234567890123455/1234",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/tests/unit/transation-schema.unit.test.ts
+++ b/tests/unit/transation-schema.unit.test.ts
@@ -12,24 +12,37 @@ describe("ApiTransactionCreateSchema", () => {
     it("accepts amount as a number", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: 1.5,
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
+      if (!result.success) {
+        // Log error for debugging
+        // eslint-disable-next-line no-console
+        console.error("Error for amount as a number:", result.error);
+      }
       expect(result.success).toBe(true);
     });
 
     it("accepts amount as a valid string number", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: "2.3",
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
+      if (!result.success) {
+        // eslint-disable-next-line no-console
+        console.error("Error for amount as a valid string number:", result.error);
+      }
       expect(result.success).toBe(true);
     });
 
     it("accepts amount as a valid scientific notation string", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: "1e3",
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
+      if (!result.success) {
+        // eslint-disable-next-line no-console
+        console.error("Error for amount as a valid scientific notation string:", result.error);
+      }
       expect(result.success).toBe(true);
     });
   });
@@ -38,7 +51,7 @@ describe("ApiTransactionCreateSchema", () => {
     it("rejects amount as an invalid string with letters", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: "1mama123",
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
       expect(result.success).toBe(false);
     });
@@ -46,7 +59,7 @@ describe("ApiTransactionCreateSchema", () => {
     it("rejects amount as an empty string", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: "",
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
       expect(result.success).toBe(false);
     });
@@ -54,7 +67,7 @@ describe("ApiTransactionCreateSchema", () => {
     it("rejects amount as zero", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: 0,
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
       expect(result.success).toBe(false);
     });
@@ -62,14 +75,14 @@ describe("ApiTransactionCreateSchema", () => {
     it("rejects amount as negative", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: -1,
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
       expect(result.success).toBe(false);
     });
 
     it("rejects missing amount", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
-        toBankNumber: "1234567890123455/5555",
+        toBankNumber: "555555555555/5555",
       });
       expect(result.success).toBe(false);
     });
@@ -84,7 +97,7 @@ describe("ApiTransactionCreateSchema", () => {
     it("rejects invalid toBankNumber format", () => {
       const result = safeParse(ApiTransactionCreateSchema, {
         amount: 1,
-        toBankNumber: "1234567890123455/1234",
+        toBankNumber: "555555555555/1234",
       });
       expect(result.success).toBe(false);
     });


### PR DESCRIPTION
- Updated the preprocessing function to only accept valid number strings (integer or decimal).
- Added regex validation to ensure strings are properly formatted before parsing.
- Invalid strings will now return undefined, improving overall validation accuracy.


Resolving https://czechitas-jira.atlassian.net/browse/CZBANK-3